### PR TITLE
Fix quotes in the github actions workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,7 +43,7 @@ jobs:
                   path: |
                       ${{ steps.determine-composer-cache-directory.outputs.directory }}
                       ${{ github.workspace }}/vendor
-                  key: 'php-${{ matrix.php }}-${{ hashFiles("composer.lock") }}'
+                  key: "php-${{ matrix.php }}-${{ hashFiles('composer.lock') }}"
                   restore-keys: 'php-${{ matrix.php }}-'
             - uses: 'ramsey/composer-install@v2'
               with:
@@ -71,7 +71,7 @@ jobs:
                   path: |
                       ${{ steps.determine-composer-cache-directory.outputs.directory }}
                       ${{ github.workspace }}/vendor
-                  key: 'php-${{ matrix.php }}-${{ hashFiles("composer.lock") }}'
+                  key: "php-${{ matrix.php }}-${{ hashFiles('composer.lock') }}"
                   restore-keys: 'php-${{ matrix.php }}-'
             - uses: 'ramsey/composer-install@v2'
               with:
@@ -99,7 +99,7 @@ jobs:
                   path: |
                       ${{ steps.determine-composer-cache-directory.outputs.directory }}
                       ${{ github.workspace }}/vendor
-                  key: 'php-${{ matrix.php }}-${{ hashFiles("composer.lock") }}'
+                  key: "php-${{ matrix.php }}-${{ hashFiles('composer.lock') }}"
                   restore-keys: 'php-${{ matrix.php }}-'
             - uses: 'ramsey/composer-install@v2'
               with:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,7 +17,7 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@v2'
-            - uses: 'shivammathur/setup-php@v2.21.1'
+            - uses: 'shivammathur/setup-php@v2'
               with:
                   php-version: '${{ matrix.php }}'
             - run: 'find src/ -type f -name "*.php" -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )'
@@ -29,7 +29,7 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@v2'
-            - uses: 'shivammathur/setup-php@v2.21.1'
+            - uses: 'shivammathur/setup-php@v2'
               with:
                   coverage: 'none'
                   php-version: '${{ matrix.php }}'
@@ -57,7 +57,7 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@v2'
-            - uses: 'shivammathur/setup-php@v2.21.1'
+            - uses: 'shivammathur/setup-php@v2'
               with:
                   coverage: 'none'
                   php-version: '${{ matrix.php }}'
@@ -85,7 +85,7 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@v2'
-            - uses: 'shivammathur/setup-php@v2.21.1'
+            - uses: 'shivammathur/setup-php@v2'
               with:
                   coverage: 'none'
                   php-version: '${{ matrix.php }}'


### PR DESCRIPTION
Noticed that main was red: https://github.com/packagist/vendor-data-exporter/actions/runs/4914689668

