### PR TITLE
Add zizmor GitHub Actions security analysis 🌈 + harden security

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,6 +8,9 @@ on:
         branches:
             - 'main'
 
+permissions:
+    contents: read
+
 jobs:
     code-style:
         runs-on: 'ubuntu-22.04'
@@ -16,6 +19,8 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4
+              with:
+                  persist-credentials: false
             - uses: 'shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45' # v2
               with:
                   coverage: 'none'
@@ -44,6 +49,8 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4
+              with:
+                  persist-credentials: false
             - uses: 'shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45' # v2
               with:
                   coverage: 'none'
@@ -72,6 +79,8 @@ jobs:
                 php: ['8.1']
         steps:
             - uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4
+              with:
+                  persist-credentials: false
             - uses: 'shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45' # v2
               with:
                   coverage: 'none'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/workflows/*.yml'
+            - '.github/workflows/*.yaml'
+    pull_request:
+        paths:
+            - '.github/workflows/*.yml'
+            - '.github/workflows/*.yaml'
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  online-audits: false


### PR DESCRIPTION
Adds [zizmor](https://github.com/zizmorcore/zizmor) as a GitHub Actions security analysis workflow, mirroring the setup in `private-packagist`.

Fixes the issues zizmor as found